### PR TITLE
fix(test): force file modification to trigger pull request diff

### DIFF
--- a/src/net_diag.py
+++ b/src/net_diag.py
@@ -4,21 +4,22 @@ import sys
 def run_connectivity_check(target_host):
     """
     Utility to verify latency against internal services.
-    Currently used by the ops-dashboard.
+    Sanitized implementation avoiding shell injection.
     """
-    # VULNERABILIDAD: Inyección de comandos directa
-    command = f"ping -c 1 {target_host}"
+    # FIX: Usar lista de argumentos evita la shell del sistema.
+    # El sistema operativo pasa 'target_host' como argumento, no como comando.
+    command = ["ping", "-c", "1", target_host]
     
     try:
-        # El LLM debe detectar: Input no sanitizado + shell=True
-        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
-        return output.decode('utf-8')
+        # shell=False es el default, pero lo omitimos explícitamente por claridad
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        return result.stdout
     except subprocess.CalledProcessError as e:
-        return f"Error checking {target_host}: {e.output}"
+        return f"Error checking {target_host}: {e.stderr}"
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python net_diag.py <hostname>")
         sys.exit(1)
     
-    print(run_connectivity_check(sys.argv[1]))# Trigger CI/CD execution check
+    print(run_connectivity_check(sys.argv[1]))


### PR DESCRIPTION
## Context
As part of the initiative to improve observability on the internal status page (see ticket OPS-402), we need a lightweight method to verify connectivity and latency to downstream dependencies.

## Changes
- Added `net_diag.py`: A standalone Python script acting as a wrapper around system `ping`.
- Configured execution context to allow shell command processing for compatibility with the base Alpine image.

## Validation
- [x] Tested locally: `python net_diag.py 8.8.8.8` returns valid latency stats.