### PR TITLE
docs: refine ADRs contexct for professional aligment

### DIFF
--- a/docs/adr/0001-patron-gatekeeper-local.md
+++ b/docs/adr/0001-patron-gatekeeper-local.md
@@ -10,7 +10,7 @@ Este problema presenta un dilema arquitectónico: necesitamos la capacidad anal�
 
 ### Restricciones identificadas:
 - El código analizado puede contener secretos hardcodeados
-- Las APIs de LLM (Claude, Gemini) procesan datos en servidores externos
+- Las APIs de LLM basadas en SaaS (como Google Vertex AI, Anthropic Claude o OpenAI) procesan datos en infraestructura multi-tenant fuera del perímetro de seguridad corporativo
 - El envío de secretos a terceros viola políticas de seguridad corporativas
 - La detección de secretos mediante LLM es redundante cuando existen soluciones deterministas probadas
 

--- a/docs/adr/0003-telemetria-y-finops.md
+++ b/docs/adr/0003-telemetria-y-finops.md
@@ -10,10 +10,10 @@ Los costes de inferencia de LLMs y la latencia son factores críticos para la ad
 2. **Latencia excesiva**: Checks lentos bloquean el flujo de desarrollo y frustran a los desarrolladores
 3. **Opacidad**: Sin datos empíricos, la selección de modelo (Gemini Flash vs Claude Sonnet) se basa en intuición
 
-### Requisitos del proyecto académico:
-- El Trabajo Fin de Máster (TFM) requiere justificación cuantitativa de las decisiones técnicas
-- La comparativa de modelos debe basarse en datos reales, no en benchmarks teóricos
-- El tribunal evaluará la metodología de medición y análisis de costes
+### Restricciones de Negocio y Stakeholders:
+- Auditabilidad Financiera: La organización requiere un desglose granular de costes (Unit Economics) para justificar la adopción de GenAI.
+- Justificación de Arquitectura: La elección del modelo debe estar respaldada por métricas comparativas de latencia vs. coste, no por preferencias subjetivas.
+- Transparencia Operativa: Es mandatorio visualizar el impacto del sistema en los tiempos de bloqueo del pipeline CI/CD
 
 ## Decisión
 El sistema implementará un **"Modo de Telemetría Verbosa"** habilitado por defecto que registrará métricas estrictas para cada interacción con el LLM.


### PR DESCRIPTION
 Summary

This PR refactors the Architecture Decision Records (ADR 001 & 003) to align with industry standards. It removes specific academic references and vendor lock-in terminology, ensuring the documentation reflects a professional Engineering Strategy rather than just a thesis requirement.
Key Changes

1. ADR 0001: Gatekeeper Pattern

    Generalized Context: Replaced specific references to "Claude/Gemini" with "SaaS LLM APIs". This makes the architectural decision valid for any external provider (OpenAI, Anthropic, Vertex AI), focusing on the privacy problem rather than the specific tool.

2. ADR 0003: Telemetry & FinOps

    Professionalized Requirements: Reframed "TFM/Academic Requirements" into "Stakeholder & Business Constraints".

    Focus Shift: The justification for telemetry is now based on Auditability and Unit Economics (Enterprise Standard) rather than "passing the exam".

🏁 Checklist

    [x] ADRs now use vendor-agnostic terminology where appropriate.

    [x] "Context" sections reflect real-world business scenarios.

    [x] Markdown formatting verified.