### PR TITLE
chore: replace MIT with proprietary license and add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+OpsGuard-AI – Proprietary License
+
+Copyright (c) 2026 Óscar Sánchez Pérez. All rights reserved.
+
+This software and associated documentation files (the “Software”) are the exclusive property of the author.
+
+No permission is granted to any person or organization to use, copy, modify, merge, publish, distribute, sublicense, sell, host, deploy, or otherwise exploit the Software, in whole or in part, in any form or by any means, without explicit prior written permission from the author.
+
+Access to this repository and visibility of the source code are provided strictly for academic evaluation, portfolio review, and technical demonstration purposes only. Such access does not grant any license or rights to the Software.
+
+Unauthorized use, reproduction, redistribution, or commercial exploitation of this Software may result in legal action.
+
+The author reserves the right to grant commercial or non-commercial licenses under separate written agreements.
+
+For licensing inquiries, contact:
+contacto@oscarsp.dev

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # 🛡️ OpsGuard-AI
 > **Context-Aware Security Gate for DevOps Pipelines.**
 
-![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.12-blue)
 ![Status](https://img.shields.io/badge/status-stable-green)
 ![CI/CD](https://img.shields.io/badge/github--actions-enabled-brightgreen)
@@ -147,4 +146,14 @@ Puede consultar logs reales y capturas de funcionamiento en la carpeta de eviden
 👉 [Ver Logs y Capturas](/docs/evidence)
 
 ---
+
+⚖️ Licencia
+
+Este proyecto es software propietario.
+
+El código fuente se hace público únicamente con fines de evaluación académica y demostración técnica.
+No se concede permiso para usar, copiar, modificar, distribuir ni explotar este software sin autorización expresa y por escrito del autor.
+
+Consulte el archivo LICENSE para los términos completos.
+
 **TFM - Máster en Desarrollo con IA** | Óscar Sánchez Pérez


### PR DESCRIPTION
🔒 License Update – Transition to Proprietary Model

This PR replaces the previously referenced open-source license with a proprietary license and introduces a formal LICENSE file.

Why this change?

OpsGuard-AI is being developed as a long-term project beyond its academic evaluation. Public visibility of the repository is intended for technical review, portfolio demonstration, and academic assessment only, not for open-source reuse.

The previous license reference could legally allow third-party usage, modification, and redistribution, which does not align with the project’s intended ownership and future roadmap.

What changed?

Replaced the license badge in README.md to reflect a Proprietary license

Added a LICENSE file explicitly restricting:

Use

Copying

Modification

Redistribution

Commercial or production deployment

Impact

This change does not affect the academic evaluation of the project.
It only clarifies the legal status of the source code and protects future development rights.