### PR TITLE
fix(dashboard): fix refresh button not showing loading state

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -72,6 +72,8 @@ export default function OpsGuardMonitor() {
   const [bootSequence, setBootSequence] = useState(true);
 
   const fetchWorkflowRuns = useCallback(async () => {
+    setLoading(true);
+
     if (!GITHUB_TOKEN || !OWNER || !REPO) {
       setError('Configuration missing. Check your .env.local file.');
       setLoading(false);


### PR DESCRIPTION
## Fix: Botón de Refresh del Dashboard no respondía

### Bug
El botón de refresh (icono `RefreshCw`) del dashboard no daba feedback visual al pulsarlo. El spinner no giraba y parecía que no hacía nada.

### Causa
Faltaba `setLoading(true)` al inicio de `fetchWorkflowRuns`. Sin esto, `loading` era `false` tras la carga inicial, y al pulsar el botón no se activaba el estado de carga (spinner + disabled).

### Fix
```diff
const fetchWorkflowRuns = useCallback(async () => {
+   setLoading(true);
+
    if (!GITHUB_TOKEN || !OWNER || !REPO) {
```