### PR TITLE
fix(deps): add pathspec as explicit dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -450,14 +450,14 @@ files = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.3"
+version = "1.0.4"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
-    {file = "pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c"},
-    {file = "pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d"},
+    {file = "pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"},
+    {file = "pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645"},
 ]
 
 [package.extras]
@@ -921,4 +921,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "8dd05f4d3e564647cda3114871a6efd8ff2d01ede1ee8ff70705afbb4bd54700"
+content-hash = "93c3a506cc2d0101611f48f9dffebfdadc289568383db06237c741fdde860e55"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pyyaml = "^6.0.1"
 python-dotenv = "^1.2.1"
 # FIX: Downgrade a 13.x para satisfacer la restricción (<14.0.0) de Typer
 rich = "^13.7.0"
+pathspec = "^1.0.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## Fix: Añadir `pathspec` como dependencia explícita

`pathspec` se importa en `main.py` para parsear `.opsguardignore` (usando el formato `gitwildmatch`), pero no estaba declarada en `pyproject.toml`.

Funcionaba porque era una dependencia transitiva, pero esto es frágil y no es correcto.

### Cambio
```diff
[tool.poetry.dependencies]
+pathspec = "^1.0.4"
```