### PR TITLE
fix(ai): define missing MAX_DIFF_CHARS constant

### DIFF
--- a/src/ai.py
+++ b/src/ai.py
@@ -16,6 +16,11 @@ class AIEngineError(Exception):
 PRICE_PER_1M_INPUT = 0.10
 PRICE_PER_1M_OUTPUT = 0.40
 
+# --- DIFF PROCESSING LIMITS ---
+# Max characters sent to the LLM to control cost and avoid context window overflow.
+# Gemini Flash 2.0 supports ~1M tokens, but large diffs increase cost and latency.
+MAX_DIFF_CHARS = 30_000
+
 # SCHEMA ENFORCEMENT & CONTEXT INJECTION
 SYSTEM_PROMPT = """
 ROLE: You are OpsGuard-AI, a Senior Application Security Engineer audit bot.
@@ -78,13 +83,19 @@ class AIEngine:
 
         start_time = time.time()
         
+        # Truncado defensivo con feedback al usuario
+        original_len = len(diff_text)
+        truncated_diff = diff_text[:MAX_DIFF_CHARS]
+        if original_len > MAX_DIFF_CHARS:
+            chars_lost = original_len - MAX_DIFF_CHARS
+            print(f"⚠️  Diff truncado: {original_len} → {MAX_DIFF_CHARS} chars ({chars_lost} chars descartados)")
+
         try:
             response = self.client.chat.completions.create(
                 model=self.model,
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},
-                    # Mantenemos el truncate defensivo.
-                    {"role": "user", "content": f"Analyze this git diff:\n\n{diff_text[:30000]}"}
+                    {"role": "user", "content": f"Analyze this git diff:\n\n{truncated_diff}"}
                 ],
                 temperature=0.1, # Determinista: reduce alucinaciones
                 max_tokens=1024,


### PR DESCRIPTION
## Summary

- Define `MAX_DIFF_CHARS = 30_000` como constante nombrada en `src/ai.py`, junto a las constantes FinOps existentes.
- El commit anterior en esta rama introdujo la lógica de feedback de truncado (`diff_text[:MAX_DIFF_CHARS]`) pero omitió la declaración de la constante, causando un `NameError` en runtime en cada ejecución.
- El límite de 30k caracteres ya existía como literal hardcodeado (`diff_text[:30000]`); este cambio lo hace explícito, autodocumentado y configurable desde un único lugar.

## Blocker

Resolves: `NameError: name 'MAX_DIFF_CHARS' is not defined` — la herramienta era completamente no funcional en esta rama.

## Test plan

- [ ] `poetry run opsguard scan --path tests/fixtures/vulnerable_app` completa sin `NameError`.
- [ ] El warning de truncado aparece cuando el diff supera 30.000 caracteres.
- [ ] La ejecución normal no se ve afectada para diffs por debajo del límite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)