### PR TITLE
test(security): add unit tests and shooting range guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,40 @@ cp .env.example .env
 ```
 
 ### 3. Ejecutar Prueba de Concepto (Shooting Range)
-Hemos incluido una suite de archivos vulnerables (`tests/fixtures`) para demostrar la detección.
+Hemos incluido una suite de archivos intencionalmente vulnerables en `tests/fixtures/vulnerable_app/` para demostrar la detección. Pueden usarse de dos formas:
 
-**Comando:**
+#### 3a. Validación Automática (pytest)
+Ejecuta los tests unitarios del motor de detección. No requiere API Key.
+
 ```bash
-poetry run opsguard scan --path tests/fixtures/vulnerable_app
+poetry run pytest tests/test_security.py -v
 ```
 
-**Resultados Esperados:**
-- 🔴 **BLOCK (Regex):** `aws_creds.env` (AWS Key detectada).
-- 🔴 **BLOCK (AI Semántico):** `legacy_login.py` (SQL Injection detectada).
-- ✅ **PASS:** Archivos de documentación y código seguro.
+Valida el comportamiento del **Gate 1 (Regex)**: qué patrones bloquea, qué deja pasar al Gate 2 (IA) y que las líneas eliminadas nunca se penalizan.
+
+#### 3b. Demo Manual (Pipeline en vivo)
+Para ver el bloqueo de CI/CD en tiempo real, copie un fixture a otra ruta y abra una Pull Request:
+
+```bash
+# Ejemplo: credenciales AWS (bloqueado por Gate 1 — Regex)
+cp tests/fixtures/vulnerable_app/aws_creds.env src/aws_creds.env
+git checkout -b demo/shooting-range
+git add src/aws_creds.env && git commit -m "test: add config"
+git push origin demo/shooting-range
+# Abrir PR en GitHub → OpsGuard bloqueará el merge automáticamente
+```
+
+Consulte [`tests/fixtures/README.md`](tests/fixtures/README.md) para la guía completa con todos los fixtures y sus resultados esperados.
+
+**Inventario de Fixtures:**
+
+| Fichero | Vulnerabilidad | Gate que lo detecta |
+|---------|---------------|---------------------|
+| `aws_creds.env` | AWS Access Key (`AKIA…`) | Gate 1 — Regex |
+| `legacy_login.py` | SQL Injection | Gate 2 — IA |
+| `auth_middleware.py` | Developer Backdoor | Gate 2 — IA |
+| `config.php` | Password & API Key hardcodeadas | Gate 2 — IA |
+| `supply_chain_attack.py` | Typosquatting `ghrc.io` → `ghcr.io` | Gate 2 — IA |
 
 ---
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,109 @@
+# OpsGuard-AI — Shooting Range
+
+> Colección de archivos intencionalmente vulnerables para demostrar las capacidades de detección de OpsGuard-AI.
+
+Estos ficheros están excluidos del análisis automático de OpsGuard (ver `.opsguardignore`) porque contienen vulnerabilidades **a propósito**. Su función es doble:
+
+1. **Demostración en vivo** — el profesor puede copiar cualquier fichero a otra ruta, hacer commit y abrir una PR; OpsGuard bloqueará el pipeline.
+2. **Base de los tests unitarios** — `tests/test_security.py` los usa programáticamente para validar el motor de detección.
+
+---
+
+## Inventario de Fixtures
+
+| Fichero | Vulnerabilidad | Detectado por | Gate |
+|---------|---------------|---------------|------|
+| `vulnerable_app/aws_creds.env` | AWS Access Key hardcodeada (`AKIA…`) | Regex | **Gate 1** |
+| `vulnerable_app/legacy_login.py` | SQL Injection (f-string sin sanitizar) | IA semántica | **Gate 2** |
+| `vulnerable_app/auth_middleware.py` | Backdoor de developer (`X-DEBUG-MODE`) | IA semántica | **Gate 2** |
+| `vulnerable_app/config.php` | Password y API Key hardcodeadas (PHP) | IA semántica | **Gate 2** |
+| `vulnerable_app/supply_chain_attack.py` | Supply-Chain Typosquatting (`ghrc.io` → `ghcr.io`) | IA semántica | **Gate 2** |
+
+> **Nota de diseño:** `legacy_login.py`, `auth_middleware.py` y `config.php` pasan deliberadamente el Gate 1 (regex). Esto valida que el sistema no produce falsos positivos en vulnerabilidades semánticas y que el Gate 2 (IA) es el responsable de razonar sobre lógica de negocio y contexto.
+
+---
+
+## Demo Manual — Instrucciones para el Evaluador
+
+Siga estos pasos para ver OpsGuard en acción bloqueando un commit vulnerable en tiempo real.
+
+### Requisitos previos
+```bash
+git clone https://github.com/oscaar90/OpsGuard-AI.git
+cd OpsGuard-AI
+poetry install
+cp .env.example .env
+# Añadir OPENROUTER_API_KEY en .env
+```
+
+### Paso 1 — Elija un fixture
+
+| Si quiere ver… | Use este fichero |
+|----------------|-----------------|
+| Bloqueo inmediato por regex (Gate 1) | `aws_creds.env` |
+| Bloqueo por IA — SQL Injection (Gate 2) | `legacy_login.py` |
+| Bloqueo por IA — Backdoor (Gate 2) | `auth_middleware.py` |
+
+### Paso 2 — Copie el fichero a una ruta analizada
+
+```bash
+# Ejemplo con el fichero de credenciales AWS
+cp tests/fixtures/vulnerable_app/aws_creds.env src/aws_creds.env
+```
+
+### Paso 3 — Añada y commitee el cambio
+
+```bash
+git checkout -b demo/shooting-range
+git add src/aws_creds.env
+git commit -m "test: add config file"
+git push origin demo/shooting-range
+```
+
+### Paso 4 — Abra una Pull Request
+
+Abra la PR desde GitHub. El workflow `opsguard.yml` se activará automáticamente y **bloqueará el merge** con una salida similar a:
+
+```
+🛡️ OpsGuard-AI — Security Gate Active
+
+🚨 DETECTED 1 STATIC VIOLATIONS:
+┌──────────────────┬──────┐
+│ Type             │ File │
+├──────────────────┼──────┤
+│ [AWS Access Key] │ Diff │
+└──────────────────┴──────┘
+
+⛔ PIPELINE BLOCKED: SECURITY VIOLATION DETECTED
+```
+
+### Paso 5 — Limpieza
+
+```bash
+git checkout main
+git branch -D demo/shooting-range
+git push origin --delete demo/shooting-range
+rm src/aws_creds.env
+```
+
+---
+
+## Validación Automática (pytest)
+
+Los mismos fixtures son utilizados por la suite de tests unitarios para validar el motor de forma programática y reproducible:
+
+```bash
+poetry run pytest tests/test_security.py -v
+```
+
+Salida esperada:
+
+```
+tests/test_security.py::TestSecurityPolicyLoading::test_loads_real_config_successfully PASSED
+tests/test_security.py::TestSecurityPolicyLoading::test_raises_on_missing_config_file PASSED
+tests/test_security.py::TestGate1SecretDetection::test_aws_access_key_triggers_violation PASSED
+tests/test_security.py::TestGate1DoesNotOverreach::test_sql_injection_passes_gate1 PASSED
+tests/test_security.py::TestGate1DoesNotOverreach::test_logic_backdoor_passes_gate1 PASSED
+tests/test_security.py::TestDiffBehavior::test_deleted_lines_are_not_flagged PASSED
+...
+```

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for the SecurityPolicy engine (src/security.py).
+
+These tests validate the deterministic Gate 1 (regex) of the Two-Gate System,
+using the same fixture files available in tests/fixtures/vulnerable_app/ for
+manual demonstrations.
+
+Key design insight validated here:
+  - Gate 1 (regex) catches secrets with known structural patterns (AWS keys, tokens…).
+  - Gate 2 (AI)    catches semantic vulnerabilities (SQL injection, logic backdoors…).
+  The tests below document WHICH gate is responsible for WHAT, so the separation
+  of concerns is explicit and verifiable.
+"""
+
+import pytest
+from pathlib import Path
+
+from src.security import SecurityPolicy, SecurityPolicyError
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+FIXTURES = Path(__file__).parent / "fixtures" / "vulnerable_app"
+CONFIG = Path(__file__).parent.parent / "opsguard.yml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def make_diff(content: str) -> str:
+    """Simulate a git diff by prefixing every line with '+'.
+
+    OpsGuard's scan_diff() only inspects added lines (starting with '+'),
+    so this helper converts raw file content into the format OpsGuard expects.
+    """
+    return "\n".join(f"+{line}" for line in content.splitlines())
+
+
+# ---------------------------------------------------------------------------
+# Policy loading
+# ---------------------------------------------------------------------------
+class TestSecurityPolicyLoading:
+    """Verify that SecurityPolicy loads and validates its configuration."""
+
+    def test_loads_real_config_successfully(self):
+        policy = SecurityPolicy(config_path=str(CONFIG))
+        assert len(policy.rules) > 0
+
+    def test_raises_on_missing_config_file(self):
+        with pytest.raises(SecurityPolicyError, match="not found"):
+            SecurityPolicy(config_path="nonexistent.yml")
+
+    def test_raises_when_blocklist_section_is_absent(self, tmp_path):
+        bad = tmp_path / "bad.yml"
+        bad.write_text("other_key: value\n")
+        with pytest.raises(SecurityPolicyError, match="blocklist"):
+            SecurityPolicy(config_path=str(bad))
+
+    def test_raises_on_invalid_yaml(self, tmp_path):
+        bad = tmp_path / "bad.yml"
+        bad.write_text("blocklist: [\n  - unclosed bracket\n")
+        with pytest.raises(SecurityPolicyError):
+            SecurityPolicy(config_path=str(bad))
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — secrets caught by regex (should BLOCK)
+# ---------------------------------------------------------------------------
+class TestGate1SecretDetection:
+    """Gate 1 must block files that contain hardcoded secrets with known patterns."""
+
+    @pytest.fixture(autouse=True)
+    def policy(self):
+        self.policy = SecurityPolicy(config_path=str(CONFIG))
+
+    def test_aws_access_key_triggers_violation(self):
+        """aws_creds.env — contains AKIA* key matched by the AWS Access Key pattern."""
+        content = (FIXTURES / "aws_creds.env").read_text()
+        violations = self.policy.scan_diff(make_diff(content))
+
+        assert len(violations) > 0, "Expected AWS key violation, got none"
+        assert any("AWS" in v for v in violations), (
+            f"Violation must reference AWS rule. Got: {violations}"
+        )
+
+    def test_aws_violation_message_contains_pattern_name(self):
+        """Each violation message must include the rule name for audit traceability."""
+        content = (FIXTURES / "aws_creds.env").read_text()
+        violations = self.policy.scan_diff(make_diff(content))
+
+        assert any("[AWS Access Key]" in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 — semantic vulnerabilities NOT caught by regex (Gate 2 responsibility)
+# ---------------------------------------------------------------------------
+class TestGate1DoesNotOverreach:
+    """Gate 1 must pass files whose vulnerabilities are semantic, not structural.
+
+    These cases are intentionally handled by Gate 2 (AI). If Gate 1 incorrectly
+    flags them, it means the regex is producing false positives that would slow
+    down the pipeline without adding security value.
+    """
+
+    @pytest.fixture(autouse=True)
+    def policy(self):
+        self.policy = SecurityPolicy(config_path=str(CONFIG))
+
+    def test_sql_injection_passes_gate1(self):
+        """legacy_login.py — SQL injection is a logic flaw, not a secret.
+
+        Gate 1 (regex) must PASS this file. Gate 2 (AI) is responsible for
+        detecting the unsanitised f-string query.
+        """
+        content = (FIXTURES / "legacy_login.py").read_text()
+        violations = self.policy.scan_diff(make_diff(content))
+
+        assert violations == [], (
+            f"SQL injection should reach Gate 2 (AI), not be blocked by Gate 1. "
+            f"Got: {violations}"
+        )
+
+    def test_logic_backdoor_passes_gate1(self):
+        """auth_middleware.py — developer backdoor is a semantic vulnerability.
+
+        The X-DEBUG-MODE bypass cannot be detected by pattern matching alone.
+        Gate 1 must let it through so Gate 2 (AI) can reason about the logic.
+        """
+        content = (FIXTURES / "auth_middleware.py").read_text()
+        violations = self.policy.scan_diff(make_diff(content))
+
+        assert violations == [], (
+            f"Logic backdoor should reach Gate 2 (AI), not be blocked by Gate 1. "
+            f"Got: {violations}"
+        )
+
+    def test_php_config_with_generic_password_passes_gate1(self):
+        """config.php — generic password in PHP array syntax is not caught by regex.
+
+        The PHP '=>' operator does not match the '=' / ':' assignment patterns
+        in opsguard.yml. This is a known limitation of Gate 1; Gate 2 (AI)
+        is responsible for detecting it via contextual reasoning.
+        """
+        content = (FIXTURES / "config.php").read_text()
+        violations = self.policy.scan_diff(make_diff(content))
+
+        assert violations == [], (
+            f"PHP generic password should reach Gate 2 (AI). Got: {violations}"
+        )
+
+    def test_supply_chain_typosquatting_passes_gate1(self):
+        """supply_chain_attack.py — typosquatting domain (ghrc.io vs ghcr.io).
+
+        There is no deterministic regex pattern that can distinguish a legitimate
+        domain from a typosquatted one. Gate 1 must pass this file; Gate 2 (AI)
+        is responsible for detecting the anomaly via contextual reasoning about
+        known registries and domain similarity.
+        """
+        content = (FIXTURES / "supply_chain_attack.py").read_text()
+        violations = self.policy.scan_diff(make_diff(content))
+
+        assert violations == [], (
+            f"Supply-chain typosquatting should reach Gate 2 (AI). Got: {violations}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Diff semantics
+# ---------------------------------------------------------------------------
+class TestDiffBehavior:
+    """Validate correct handling of diff format edge cases."""
+
+    @pytest.fixture(autouse=True)
+    def policy(self):
+        self.policy = SecurityPolicy(config_path=str(CONFIG))
+
+    def test_deleted_lines_are_not_flagged(self):
+        """Secrets on lines starting with '-' are being REMOVED — not introduced.
+
+        Removing a secret is a remediation action. Flagging it would block
+        the very commits that fix security issues.
+        """
+        diff = (
+            "-AWS_ACCESS_KEY_ID=AKIAEXAMPLEACCESSKEY\n"
+            "-AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"
+        )
+        violations = self.policy.scan_diff(diff)
+        assert violations == [], (
+            f"Removed secrets must not be flagged. Got: {violations}"
+        )
+
+    def test_diff_header_lines_are_ignored(self):
+        """Lines starting with '+++' are diff metadata, not code."""
+        diff = "+++ b/src/config.py\n+API_ENDPOINT = 'https://api.example.com'"
+        violations = self.policy.scan_diff(diff)
+        assert violations == []
+
+    def test_empty_diff_returns_no_violations(self):
+        assert self.policy.scan_diff("") == []
+
+    def test_clean_python_code_returns_no_violations(self):
+        diff = make_diff("def greet(name: str) -> str:\n    return f'Hello, {name}'")
+        assert self.policy.scan_diff(diff) == []
+
+    def test_multiple_secrets_in_one_diff_all_reported(self):
+        """When a diff introduces multiple secrets, every one must be reported."""
+        diff = (
+            "+AWS_ACCESS_KEY_ID=AKIAEXAMPLEACCESSKEY\n"
+            "+GITHUB_TOKEN=ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ123456789A\n"
+        )
+        violations = self.policy.scan_diff(diff)
+        assert len(violations) >= 2, (
+            f"Expected at least 2 violations, got {len(violations)}: {violations}"
+        )


### PR DESCRIPTION
## Summary

- `tests/test_security.py`: 15 tests unitarios (pytest) que cubren el motor de Gate 1 (regex): carga de configuración, detección de secretos, separación Gate 1 / Gate 2, y edge cases de formato diff (líneas eliminadas, cabeceras, diff vacío).
- `tests/fixtures/README.md`: guía paso a paso para que los evaluadores realicen la demo manual (Shooting Range), con inventario de los 5 fixtures y su atribución de gate.
- `README.md`: sección Shooting Range ampliada con comando pytest, flujo de demo manual e inventario completo de fixtures incluyendo `supply_chain_attack.py`.

## Diseño de los tests

Los tests no solo verifican que el motor detecta secretos, sino que también documentan explícitamente la **separación de responsabilidades entre Gate 1 y Gate 2**:

- `TestGate1SecretDetection`: valida que AWS keys (patrón estructural) son bloqueadas por regex.
- `TestGate1DoesNotOverreach`: valida que SQL injection, backdoors, typosquatting y passwords PHP **no** son bloqueados por regex (deben llegar al Gate 2 / IA).
- `TestDiffBehavior`: valida edge cases del formato diff (líneas `-` no penalizadas, cabeceras `+++` ignoradas).

## Test plan

- [x] `poetry run pytest tests/test_security.py -v` → 15 passed en 0.04s
- [ ] CI/CD verde tras merge

Closes FEEDBACK.md §2 (ausencia de tests unitarios reales).

Generated with Claude Code