### PR TITLE
fix(config): read OPSGUARD_RISK_THRESHOLD from environment

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -122,8 +122,9 @@ def scan(
 
     risk_score = ai_result.get("risk_score", 0)
     verdict = ai_result.get("verdict", "APPROVE")
-    
-    if verdict == "BLOCK" or risk_score >= 7:
+    risk_threshold = int(os.getenv("OPSGUARD_RISK_THRESHOLD", "7"))
+
+    if verdict == "BLOCK" or risk_score >= risk_threshold:
         OpsGuardUI.print_block_message()
         sys.exit(1)
     else:


### PR DESCRIPTION
## Summary

El threshold de riesgo estaba hardcodeado como `7` en `src/main.py` mientras el workflow de CI/CD ya declaraba `OPSGUARD_RISK_THRESHOLD: 7` como variable de entorno, creando una falsa impresión de configurabilidad.

**Cambio:**
```python
# Antes
if verdict == "BLOCK" or risk_score >= 7:

# Después
risk_threshold = int(os.getenv("OPSGUARD_RISK_THRESHOLD", "7"))
if verdict == "BLOCK" or risk_score >= risk_threshold:
```

Ahora los operadores pueden ajustar la sensibilidad del Gate 2 cambiando únicamente la variable de entorno en el workflow, sin tocar el código fuente.

## Test plan

- [ ] Comportamiento por defecto inalterado (threshold=7 si no se define la variable).
- [ ] Con `OPSGUARD_RISK_THRESHOLD=5` un score de 6 bloquea el pipeline.
- [ ] Con `OPSGUARD_RISK_THRESHOLD=9` un score de 8 aprueba el pipeline.

Closes FEEDBACK.md §3.2

Generated with Claude Code