### PR TITLE
fix(ci): remove unused pull-requests write permission

### DIFF
--- a/.github/workflows/opsguard.yml
+++ b/.github/workflows/opsguard.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write # Necesario para comentar en el PR (Futuro)
     
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

El permiso `pull-requests: write` estaba declarado en el workflow con un comentario que lo reconocía como funcionalidad futura no implementada.

Conceder permisos no utilizados viola el **principio de mínimo privilegio**: si el token del workflow es comprometido (ej. mediante una PR maliciosa con un GitHub Actions injection), el atacante obtendría capacidad de escritura sobre PRs innecesariamente.

**Cambio:**
```yaml
# Antes
permissions:
  contents: read
  pull-requests: write # Necesario para comentar en el PR (Futuro)

# Después
permissions:
  contents: read
```

Cuando se implemente la funcionalidad de comentarios automáticos en PRs, este permiso se restaurará con la implementación real.

## Test plan

- [ ] El workflow sigue ejecutándose correctamente en PRs (solo necesita `contents: read`).
- [ ] El job no falla por permisos insuficientes.

Closes FEEDBACK.md §3.3

Generated with Claude Code