### PR TITLE
fix(ingest): replace SKIP_SCAN string matching with typed exception

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -12,6 +12,15 @@ class GitIngestError(Exception):
     pass
 
 
+class SkipScanSignal(GitIngestError):
+    """Raised when the GitHub event type does not require scanning.
+
+    Examples: direct push to main, branch deletion. These are valid
+    git events but OpsGuard only operates on Pull Requests.
+    """
+    pass
+
+
 class GitManager:
     """Encapsulates gitpython operations for reading repository changes."""
 
@@ -48,8 +57,7 @@ class GitManager:
             # Si no hay objeto PR, verificamos si es un evento que debemos ignorar
             # (Merges a main, Deletes, Pushes directos)
             if "pusher" in event_data or "deleted" in event_data:
-                 # Usamos una keyword específica "SKIP_SCAN" para capturarla en main
-                 raise GitIngestError("SKIP_SCAN: Event is not a Pull Request (Push/Delete detected).")
+                raise SkipScanSignal("Event is not a Pull Request (Push/Delete detected).")
             
             raise GitIngestError("No pull_request data found in GitHub event")
 

--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,7 @@ def scan(
     # --- LAZY IMPORTS ---
     import pathspec
     from src.ai import AIEngine
-    from src.ingest import GitManager
+    from src.ingest import GitManager, SkipScanSignal
     from src.security import SecurityPolicy
     from src.console_ui import OpsGuardUI
 
@@ -70,22 +70,18 @@ def scan(
 
         diff = manager.get_diff(files=target_files)
 
-    # --- FIX 1: Graceful Exit Signal ---
     except typer.Exit:
-        # Re-lanzamos la señal de salida limpia para que Typer termine con código 0.
-        raise 
+        raise
+
+    except SkipScanSignal as e:
+        print(f"⏭️  {e}")
+        raise typer.Exit(code=0)
 
     except AttributeError:
         typer.secho("❌ API Mismatch: Asegúrate de que GitManager tenga 'get_staged_files()'.", fg=typer.colors.RED)
         sys.exit(1)
 
-    # --- FIX 2: Catch Generic Exceptions & SKIP_SCAN Signal ---
     except Exception as e:
-        # Si ingest.py lanza SKIP_SCAN (ej. borrado de rama), salimos en verde.
-        if "SKIP_SCAN" in str(e):
-            print(f"⏭️  {e}")
-            raise typer.Exit(code=0)
-            
         typer.secho(f"❌ Init Error: {e}", fg=typer.colors.RED)
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

Detectar un evento no-PR comprobando `"SKIP_SCAN" in str(e)` era frágil: cualquier cambio en el mensaje de error de `ingest.py` rompería silenciosamente la lógica de skip en `main.py` sin ningún aviso.

## Cambios

**`src/ingest.py`** — Nueva excepción tipada:
```python
class SkipScanSignal(GitIngestError):
    """Raised when the GitHub event type does not require scanning."""
    pass
```

**`src/ingest.py`** — Se lanza por tipo en lugar de embeber la keyword en el mensaje:
```python
# Antes
raise GitIngestError("SKIP_SCAN: Event is not a Pull Request...")

# Después
raise SkipScanSignal("Event is not a Pull Request (Push/Delete detected).")
```

**`src/main.py`** — Se captura por tipo, eliminando el string matching:
```python
# Antes
except Exception as e:
    if "SKIP_SCAN" in str(e):
        raise typer.Exit(code=0)

# Después
except SkipScanSignal as e:
    print(f"⏭️  {e}")
    raise typer.Exit(code=0)
```

## Test plan

- [x] `pytest tests/test_security.py -v` → 15 passed
- [ ] En CI, un push directo a main termina con exit 0 (⏭️ skip)
- [ ] En CI, una PR válida continúa el análisis normalmente

Closes FEEDBACK.md §5.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)