### PR TITLE
docs(adr): add Date and Deciders metadata to ADR-0001, 0002, 0003

### DIFF
--- a/docs/adr/0001-patron-gatekeeper-local.md
+++ b/docs/adr/0001-patron-gatekeeper-local.md
@@ -3,6 +3,13 @@
 ## Estado
 Aceptado
 
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| **Date** | 2026-02-01 |
+| **Deciders** | Óscar Sánchez Pérez |
+
 ## Contexto
 El sistema OpsGuard-AI es una GitHub Action que utiliza modelos de lenguaje (LLMs) para detectar vulnerabilidades de seguridad en código fuente. Sin embargo, enviar código que potencialmente contiene secretos (claves API, contraseñas, tokens de acceso) a una API externa de LLM constituye en sí mismo una fuga de datos sensibles.
 

--- a/docs/adr/0002-prompting-en-ingles.md
+++ b/docs/adr/0002-prompting-en-ingles.md
@@ -3,6 +3,13 @@
 ## Estado
 Aceptado
 
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| **Date** | 2026-02-01 |
+| **Deciders** | Óscar Sánchez Pérez |
+
 ## Contexto
 OpsGuard-AI utiliza modelos de lenguaje (Claude de Anthropic, Gemini de Google) como motor de razonamiento para detectar vulnerabilidades de seguridad en código. La elección del idioma para los prompts del sistema tiene implicaciones directas en:
 

--- a/docs/adr/0003-telemetria-y-finops.md
+++ b/docs/adr/0003-telemetria-y-finops.md
@@ -3,6 +3,13 @@
 ## Estado
 Aceptado
 
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| **Date** | 2026-02-01 |
+| **Deciders** | Óscar Sánchez Pérez |
+
 ## Contexto
 Los costes de inferencia de LLMs y la latencia son factores críticos para la adopción de OpsGuard-AI en pipelines de CI/CD reales. Las objeciones principales de los equipos de ingeniería ante herramientas basadas en LLM son:
 


### PR DESCRIPTION
## Summary

ADR-0001, ADR-0002 y ADR-0003 carecían de los campos `Date` y `Deciders` requeridos por el formato MADR estándar.

Añade una tabla `## Metadata` a cada ADR con:
- **Date:** `2026-02-01` (fecha de entrega del TFM inicial)
- **Deciders:** `Óscar Sánchez Pérez` (autor del TFM)

Cierra: FEEDBACK.md §9.4

## Test plan

- [ ] Los 3 ADRs renderizan correctamente en GitHub con la tabla Metadata visible
- [ ] La sección `## Estado` sigue siendo la primera sección del documento
- [ ] No se altera el contenido técnico de ningún ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)