### PR TITLE
fix(docs): correct git clone URL and personalize pyproject authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Requisitos: Python 3.12+ y [Poetry](https://python-poetry.org/docs/).
 
 ```bash
 # 1. Clonar repositorio
-git clone [https://github.com/oscaar90/OpsGuard-AI.git](https://github.com/oscaar90/OpsGuard-AI.git)
+git clone https://github.com/oscaar90/OpsGuard-AI.git
 cd OpsGuard-AI
 
 # 2. Instalar dependencias (Entorno virtual aislado)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "opsguard-ai"
 version = "0.1.0"
 description = "AI-powered DevOps guardian GitHub Action"
-authors = ["Your Name <you@example.com>"]
+authors = ["Óscar Sánchez Pérez <oscaar90@gmail.com>"]
 readme = "README.md"
 packages = [{include = "src"}]
 


### PR DESCRIPTION
## Summary

- **README.md §9.2**: La URL del `git clone` estaba envuelta en un link Markdown `[url](url)` dentro de un bloque de código, lo que hacía que se copiara con la sintaxis Markdown en lugar de la URL limpia. Corregido a URL directa.
- **pyproject.toml §9.1**: El campo `authors` tenía el valor placeholder `Your Name <you@example.com>`. Reemplazado por el nombre real del autor del TFM.

Cierra: FEEDBACK.md §9.2, §9.1

## Test plan

- [ ] README.md: el bloque `git clone` muestra la URL limpia sin corchetes
- [ ] pyproject.toml: `authors` contiene el nombre y email del autor real
- [ ] `poetry check` no reporta errores de metadatos

🤖 Generated with [Claude Code](https://claude.com/claude-code)