### PR TITLE
fix(ai): read LLM model from OPSGUARD_MODEL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,10 @@
 OPENROUTER_API_KEY=""
+
+# Optional: override the LLM model used by Gate 2 (default: google/gemini-2.0-flash-001)
+# OPSGUARD_MODEL="google/gemini-2.0-flash-001"
+
+# Optional: risk score threshold to trigger a BLOCK (default: 7)
+# OPSGUARD_RISK_THRESHOLD="7"
+
+# Optional: telemetry verbosity — verbose | summary | silent (default: verbose)
+# OPSGUARD_TELEMETRY_MODE="verbose"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Cada entrada está vinculada a su Pull Request en GitHub para trazabilidad compl
   - Rama: `fix/skip-scan-typed-exception` → `main`
   - Cierra: FEEDBACK.md §5.2
 
+- **[PR #36]** Modelo LLM hardcodeado — `self.model` leído ahora desde `OPSGUARD_MODEL` env var con `google/gemini-2.0-flash-001` como valor por defecto. El comportamiento sin configuración adicional es idéntico. Permite cambiar de modelo (p.ej. a `google/gemini-2.0-flash-thinking-exp` o cualquier modelo de OpenRouter) sin tocar código fuente, igual que ya funcionan `OPSGUARD_RISK_THRESHOLD` y `OPSGUARD_TELEMETRY_MODE`. Se actualiza `.env.example` con todas las variables disponibles y se añade tabla de referencia en el README.
+  - Ficheros: `src/ai.py`, `.env.example`, `README.md`
+  - Rama: `fix/model-from-env-var` → `main`
+  - Cierra: FEEDBACK.md §8.1
+
 - **[PR #34]** URL `git clone` malformada en README y `authors` sin personalizar en `pyproject.toml` — La URL del Quick Start estaba envuelta en sintaxis Markdown `[url](url)` dentro de un bloque de código, haciendo que se copiara con corchetes en lugar de como URL limpia. El campo `authors` contenía el placeholder `Your Name <you@example.com>`. Ambos corregidos.
   - Ficheros: `README.md`, `pyproject.toml`
   - Rama: `fix/readme-clone-url-and-authors` → `main`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ cp .env.example .env
 # Edite .env y pegue la variable OPENROUTER_API_KEY
 ```
 
+El sistema es configurable mediante variables de entorno sin modificar código:
+
+| Variable | Descripción | Por defecto |
+|----------|-------------|-------------|
+| `OPENROUTER_API_KEY` | API Key de OpenRouter (**obligatoria**) | — |
+| `OPSGUARD_MODEL` | Modelo LLM a usar en Gate 2 | `google/gemini-2.0-flash-001` |
+| `OPSGUARD_RISK_THRESHOLD` | Puntuación mínima para bloquear | `7` |
+| `OPSGUARD_TELEMETRY_MODE` | Verbosidad de telemetría FinOps (`verbose` / `summary` / `silent`) | `verbose` |
+
 ### 3. Ejecutar Prueba de Concepto (Shooting Range)
 Hemos incluido una suite de archivos intencionalmente vulnerables en `tests/fixtures/vulnerable_app/` para demostrar la detección. Pueden usarse de dos formas:
 

--- a/src/ai.py
+++ b/src/ai.py
@@ -84,8 +84,7 @@ class AIEngine:
             timeout=60.0
         )
         
-        # Mantenemos Gemini Flash 2.0 por su ventana de contexto y capacidad de razonamiento
-        self.model = "google/gemini-2.0-flash-001"
+        self.model = os.getenv("OPSGUARD_MODEL", "google/gemini-2.0-flash-001")
 
     def analyze_diff(self, diff_text: str) -> Dict[str, Any]:
         if TELEMETRY_MODE != "silent":


### PR DESCRIPTION
## Summary

- `src/ai.py`: `self.model` era `"google/gemini-2.0-flash-001"` hardcodeado. Ahora se lee de `OPSGUARD_MODEL` con ese mismo valor como default — comportamiento sin cambios si la variable no está definida.
- `.env.example`: documentadas todas las variables de entorno disponibles (`OPSGUARD_MODEL`, `OPSGUARD_RISK_THRESHOLD`, `OPSGUARD_TELEMETRY_MODE`) con sus valores por defecto, comentadas para no activarse accidentalmente.
- `README.md`: tabla de referencia de variables de entorno añadida en la sección de Configuración del Quick Start.
- `CHANGELOG.md`: entrada para PR #36.

Cierra: FEEDBACK.md §8.1

## Test plan

- [ ] Sin `OPSGUARD_MODEL` definida: el sistema usa `google/gemini-2.0-flash-001` (comportamiento anterior)
- [ ] Con `OPSGUARD_MODEL=google/gemini-2.0-flash-thinking-exp`: el engine usa el modelo especificado
- [ ] `poetry run pytest tests/test_security.py -v` sigue pasando sin cambios
- [ ] `.env.example` muestra las 4 variables con descripciones claras

🤖 Generated with [Claude Code](https://claude.com/claude-code)