### PR TITLE
fix(style): homogenize all Spanish comments to English (ADR-0002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Cada entrada está vinculada a su Pull Request en GitHub para trazabilidad compl
   - Rama: `fix/skip-scan-typed-exception` → `main`
   - Cierra: FEEDBACK.md §5.2
 
+- **[PR #37]** Comentarios en español homogeneizados a inglés — 12 comentarios y un docstring en `src/console_ui.py`, `src/ingest.py`, `src/main.py` y `pyproject.toml` usaban español, violando ADR-0002 (todos los artefactos técnicos en inglés). Traducidos al inglés manteniendo el significado exacto.
+  - Ficheros: `src/console_ui.py`, `src/ingest.py`, `src/main.py`, `pyproject.toml`
+  - Rama: `fix/spanish-comments-to-english` → `main`
+  - Cierra: FEEDBACK.md §4.3
+
 - **[PR #36]** Modelo LLM hardcodeado — `self.model` leído ahora desde `OPSGUARD_MODEL` env var con `google/gemini-2.0-flash-001` como valor por defecto. El comportamiento sin configuración adicional es idéntico. Permite cambiar de modelo (p.ej. a `google/gemini-2.0-flash-thinking-exp` o cualquier modelo de OpenRouter) sin tocar código fuente, igual que ya funcionan `OPSGUARD_RISK_THRESHOLD` y `OPSGUARD_TELEMETRY_MODE`. Se actualiza `.env.example` con todas las variables disponibles y se añade tabla de referencia en el README.
   - Ficheros: `src/ai.py`, `.env.example`, `README.md`
   - Rama: `fix/model-from-env-var` → `main`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-# Mantenemos Typer con extras para shell completion
+# Keep Typer with extras for shell completion
 typer = {extras = ["all"], version = "^0.9.0"}
 pydantic = "^2.5.0"
 gitpython = "^3.1.40"
 openai = "^1.6.0"
 pyyaml = "^6.0.1"
 python-dotenv = "^1.2.1"
-# FIX: Downgrade a 13.x para satisfacer la restricción (<14.0.0) de Typer
+# FIX: downgrade to 13.x to satisfy Typer's upper bound (<14.0.0)
 rich = "^13.7.0"
 pathspec = "^1.0.4"
 

--- a/src/console_ui.py
+++ b/src/console_ui.py
@@ -39,7 +39,7 @@ class OpsGuardUI:
         explanation = result.get("explanation", "No details.")
         findings = result.get("findings", [])
 
-        # Semáforo
+        # Verdict traffic light
         if verdict == "APPROVE":
             v_style = "bold green"
         else:
@@ -62,7 +62,7 @@ class OpsGuardUI:
 
             for finding in findings:
                 sev = finding.get("severity", "UNK")
-                # Highlighting crítico
+                # Critical severity highlighting
                 sev_color = "red" if sev in ["CRITICAL", "HIGH"] else "yellow"
                 
                 table.add_row(

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -50,12 +50,12 @@ class GitManager:
         except json.JSONDecodeError as e:
             raise GitIngestError(f"Failed to parse GitHub event JSON: {e}")
 
-        # --- FIX: DETECCIÓN DE EVENTOS NO-PR ---
+        # --- FIX: NON-PR EVENT DETECTION ---
         pull_request = event_data.get("pull_request")
-        
+
         if not pull_request:
-            # Si no hay objeto PR, verificamos si es un evento que debemos ignorar
-            # (Merges a main, Deletes, Pushes directos)
+            # No PR object — check if this is an event we should skip
+            # (merges to main, branch deletions, direct pushes)
             if "pusher" in event_data or "deleted" in event_data:
                 raise SkipScanSignal("Event is not a Pull Request (Push/Delete detected).")
             
@@ -99,7 +99,7 @@ class GitManager:
         Returns:
             The git diff as a string.
         """
-        # Preparar argumentos extra para gitpython (file filtering)
+        # Build extra args for gitpython (file filtering)
         # git diff <commit> -- file1 file2
         extra_args = ["--"] + files if files else []
 

--- a/src/main.py
+++ b/src/main.py
@@ -35,7 +35,7 @@ def scan(
     OpsGuardUI.print_banner()
 
     def _load_ignore_spec(root: Path) -> pathspec.PathSpec:
-        """Carga patrones de exclusión."""
+        """Load exclusion patterns from .opsguardignore."""
         ignore_path = root / ".opsguardignore"
         lines = []
         if ignore_path.exists():
@@ -65,7 +65,7 @@ def scan(
 
         if not target_files:
             print("✨ No relevant changes detected (filtered by .opsguardignore).")
-            # Esto lanza una excepción 'Exit' que debemos dejar pasar
+            # typer.Exit is intentional — let it propagate
             raise typer.Exit(code=0)
 
         diff = manager.get_diff(files=target_files)
@@ -89,7 +89,7 @@ def scan(
         print("✨ Empty diff content.")
         raise typer.Exit(code=0)
 
-    # 2. FASE 1: Deterministic Shield (Regex)
+    # 2. Gate 1: Deterministic Shield (Regex)
     violations = policy.scan_diff(diff)
 
     if violations:
@@ -100,7 +100,7 @@ def scan(
 
     OpsGuardUI.print_regex_findings([]) 
 
-    # 3. FASE 2: Semantic Brain (AI Analysis)
+    # 3. Gate 2: Semantic Brain (AI Analysis)
     api_key = os.getenv("OPENROUTER_API_KEY")
     if not api_key:
         typer.secho("⚠️ Missing OPENROUTER_API_KEY. Skipping AI.", fg=typer.colors.YELLOW)
@@ -113,7 +113,7 @@ def scan(
         typer.secho(f"❌ AI Engine Error: {e}", fg=typer.colors.RED)
         sys.exit(1)
 
-    # 4. Reporte
+    # 4. Report
     OpsGuardUI.print_ai_analysis(ai_result)
 
     risk_score = ai_result.get("risk_score", 0)


### PR DESCRIPTION
## Summary

12 comentarios inline y un docstring en `src/` y `pyproject.toml` estaban escritos en español, violando **ADR-0002** (todos los artefactos técnicos en inglés). Traducidos al inglés preservando el significado exacto.

| Fichero | Cambios |
|---------|--------|
| `src/console_ui.py` | `# Semáforo` → `# Verdict traffic light`; `# Highlighting crítico` → `# Critical severity highlighting` |
| `src/ingest.py` | `# DETECCIÓN DE EVENTOS NO-PR` → `# NON-PR EVENT DETECTION`; comentarios inline del bloque if |
| `src/main.py` | Docstring `Carga patrones`; `FASE 1/2` → `Gate 1/2`; `# Reporte` → `# Report`; comentario typer.Exit |
| `pyproject.toml` | 2 comentarios de dependencias |

Cierra: FEEDBACK.md §4.3

## Test plan

- [ ] `grep -rn "#.*[áéíóúüñ]" src/ pyproject.toml` no devuelve resultados
- [ ] `poetry run pytest tests/test_security.py -v` sigue pasando
- [ ] Ningún comportamiento en runtime se ha modificado

🤖 Generated with [Claude Code](https://claude.com/claude-code)