### PR TITLE
fix: translate Spanish error string in main.py to English (ADR-0002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Cada entrada está vinculada a su Pull Request en GitHub para trazabilidad compl
 
 ### Fixed
 
+- **[PR #42]** Cadena de error en español en `src/main.py` traducida a inglés — `"Asegúrate de que GitManager tenga 'get_staged_files()'"` violaba ADR-0002. Última instancia de español en artefactos técnicos del proyecto.
+  - Fichero: `src/main.py`
+  - Rama: `fix/spanish-string-main-py` → `main`
+  - Cierra: ADR-0002 (100% cumplimiento)
+
 - **[PR #41]** Eliminación de dependencia fantasma `pydantic` y homogeneización de comentarios a inglés — `pydantic ^2.5.0` estaba declarado como dependencia de producción en `pyproject.toml` pero nunca importado en ningún módulo de `src/`. Se elimina para reducir el grafo de dependencias. Adicionalmente se traducen al inglés los comentarios restantes en español en `.github/workflows/opsguard.yml`, `.opsguardignore` y `src/console_ui.py` (`# --- TABLA FORENSE ---`), cerrando la última deuda detectada en el análisis de calidad de código.
   - Ficheros: `pyproject.toml`, `.github/workflows/opsguard.yml`, `.opsguardignore`, `src/console_ui.py`
   - Rama: `fix/code-quality-remaining` → `main`

--- a/src/main.py
+++ b/src/main.py
@@ -78,7 +78,7 @@ def scan(
         raise typer.Exit(code=0)
 
     except AttributeError:
-        typer.secho("❌ API Mismatch: Asegúrate de que GitManager tenga 'get_staged_files()'.", fg=typer.colors.RED)
+        typer.secho("❌ API Mismatch: GitManager is missing the 'get_staged_files()' method.", fg=typer.colors.RED)
         sys.exit(1)
 
     except Exception as e:


### PR DESCRIPTION
The AttributeError handler in src/main.py contained a Spanish-language error message ("Asegúrate de que GitManager tenga 'get_staged_files()'"), violating ADR-0002 which mandates English for all technical artifacts.

Translated to: "GitManager is missing the 'get_staged_files()' method."

This is the last remaining Spanish string in the codebase, achieving full ADR-0002 compliance across all source files.