### PR TITLE
feat: cache CI SHAs in GitManager and add sequence diagram to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ Cada entrada está vinculada a su Pull Request en GitHub para trazabilidad compl
 
 > Ciclo de mejora continua iniciado tras un análisis técnico exhaustivo del proyecto (`FEEDBACK.md`). Las correcciones cubren dos categorías: **blockers de runtime** que impedían la ejecución en entornos limpios, y **deuda técnica** que comprometía la configurabilidad y el principio de mínimo privilegio.
 
+### Added
+
+- **[PR #43]** Sequence diagram de actores en runtime añadido al README — complementa el flowchart de alto nivel con un diagrama de secuencia Mermaid que muestra los actores reales (GitHub Actions, Gate 1, Gate 2, OpenRouter API) y los flujos condicionales de BLOCK/APPROVE con sus notas de contexto (ADR-0001).
+  - Fichero: `README.md`
+  - Rama: `feat/architecture-improvements` → `main`
+
 ### Fixed
+
+- **[PR #43]** `_get_ci_shas()` se llamaba dos veces por ejecución — una en `get_staged_files()` y otra en `_get_ci_diff()`, parseando el fichero JSON del evento de GitHub dos veces. Se introduce `self._shas_cache` en `__init__`: la primera llamada parsea y almacena el resultado; las siguientes lo reutilizan directamente.
+  - Fichero: `src/ingest.py`
+  - Rama: `feat/architecture-improvements` → `main`
 
 - **[PR #42]** Cadena de error en español en `src/main.py` traducida a inglés — `"Asegúrate de que GitManager tenga 'get_staged_files()'"` violaba ADR-0002. Última instancia de español en artefactos técnicos del proyecto.
   - Fichero: `src/main.py`

--- a/README.md
+++ b/README.md
@@ -142,20 +142,51 @@ El sistema analiza los `git diffs` para optimizar costes y latencia mediante un 
 ```mermaid
 graph TD
     User[Developer] -->|Git Push/PR| CLI[OpsGuard CLI]
-    
+
     subgraph "Hybrid Analysis Engine"
         CLI -->|Step 1: Static Analysis| Regex[Regex Engine]
         Regex -->|"Match Found?"| Gate1{Sensitive Pattern?}
-        
+
         Gate1 -- Yes --> Block["❌ BLOCK PIPELINE"]
         Gate1 -- No --> AI["Step 2: AI Semantic Analysis"]
-        
+
         AI -->|Contextual Reasoning| Gate2{Risk Score > 7?}
         Gate2 -- Yes --> Block
         Gate2 -- No --> Pass["✅ APPROVE DEPLOY"]
     end
-    
+
     Block & Pass --> Report["CI/CD Report (Console/GitHub)"]
+```
+
+### Sequence Diagram — Runtime Actors
+
+```mermaid
+sequenceDiagram
+    actor Dev as Developer
+    participant GHA as GitHub Actions
+    participant G1 as Gate 1 · Regex Engine
+    participant G2 as Gate 2 · AI Engine
+    participant OR as OpenRouter API
+
+    Dev->>GHA: git push → Pull Request opened
+    GHA->>G1: git diff (PR base..head)
+
+    alt Sensitive pattern detected
+        G1-->>GHA: ❌ BLOCK (exit 1)
+        Note right of G1: Secret never reaches<br/>external API (ADR-0001)
+    else No structural pattern found
+        G1->>G2: diff payload (clean)
+        G2->>OR: POST /chat/completions<br/>(model, system_prompt, diff)
+        OR-->>G2: JSON · verdict + risk_score
+
+        alt risk_score ≥ threshold (default 7)
+            G2-->>GHA: ❌ BLOCK (exit 1)
+        else risk_score < threshold
+            G2-->>GHA: ✅ APPROVE (exit 0)
+        end
+    end
+
+    GHA-->>Dev: CI check result (Pass / Fail)
 ```
 
 ---

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -30,13 +30,23 @@ class GitManager:
             self.repo = Repo(repo_path)
         except InvalidGitRepositoryError as e:
             raise GitIngestError(f"Invalid git repository at '{repo_path}': {e}")
+        # Cache for CI SHAs — _get_ci_shas() is called by both get_staged_files()
+        # and _get_ci_diff(), so we parse the GitHub event JSON only once per run.
+        self._shas_cache: Optional[Tuple[str, str]] = None
 
     def is_ci(self) -> bool:
         """Check if running in GitHub Actions CI environment."""
         return os.environ.get("GITHUB_ACTIONS") is not None
 
     def _get_ci_shas(self) -> Tuple[str, str]:
-        """Helper: Extract base and head SHAs from GitHub Event JSON."""
+        """Helper: Extract base and head SHAs from GitHub Event JSON.
+
+        Result is cached after the first call to avoid parsing the event
+        file twice per execution (once in get_staged_files, once in get_diff).
+        """
+        if self._shas_cache is not None:
+            return self._shas_cache
+
         event_path = os.environ.get("GITHUB_EVENT_PATH")
         if not event_path:
             raise GitIngestError("GITHUB_EVENT_PATH environment variable not set")
@@ -66,8 +76,9 @@ class GitManager:
 
         if not base_sha or not head_sha:
             raise GitIngestError("Missing base.sha or head.sha in pull_request event data")
-            
-        return base_sha, head_sha
+
+        self._shas_cache = (base_sha, head_sha)
+        return self._shas_cache
 
     def get_staged_files(self) -> List[str]:
         """Get list of changed filenames (for pre-filtering).


### PR DESCRIPTION
- src/ingest.py: introduce self._shas_cache (Optional[Tuple[str, str]]) in GitManager.__init__. _get_ci_shas() now returns the cached result on subsequent calls, avoiding double JSON parsing of the GitHub event file per execution (called once in get_staged_files, once in get_diff).

- README.md: add Mermaid sequenceDiagram below the existing flowchart showing runtime actors: GitHub Actions → Gate 1 (Regex) → Gate 2 (AI Engine) → OpenRouter API, with conditional BLOCK/APPROVE paths and ADR-0001 context note on the secret-isolation branch.

All 28 tests pass.