### PR TITLE
feat: restructure CI/CD into 3 jobs with Poetry cache and Python matrix

### DIFF
--- a/.github/workflows/opsguard.yml
+++ b/.github/workflows/opsguard.yml
@@ -8,34 +8,121 @@ on:
   # PR-only triggering is the recommended configuration.
 
 jobs:
-  security-audit:
-    name: 🕵️‍♂️ Semantic Security Scan
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 1 — Code Quality: formatting check (black)
+  # ─────────────────────────────────────────────────────────────────────────────
+  lint:
+    name: 🔍 Code Quality
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Required: full history needed to compare PR base and head SHAs
-      
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      
+
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-py3.12-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-py3.12-poetry-
+
       - name: Install Dependencies
-        run: poetry install --no-interaction --sync
+        run: poetry install --no-interaction
+
+      - name: Check formatting (black)
+        run: poetry run black --check src/ tests/
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 2 — Unit Tests: matrix across all supported Python versions
+  # ─────────────────────────────────────────────────────────────────────────────
+  test:
+    name: 🧪 Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-py${{ matrix.python-version }}-poetry-
+
+      - name: Install Dependencies
+        run: poetry install --no-interaction
+
+      - name: Run Test Suite
+        run: poetry run pytest tests/ -v
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 3 — Security Scan: runs only when lint + tests pass
+  # ─────────────────────────────────────────────────────────────────────────────
+  security-scan:
+    name: 🕵️‍♂️ Semantic Security Scan
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required: full history needed to compare PR base and head SHAs
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-py3.12-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-py3.12-poetry-
+
+      - name: Install Dependencies
+        run: poetry install --no-interaction
 
       - name: Run OpsGuard AI Scan
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPSGUARD_RISK_THRESHOLD: 7
-        run: |
-          poetry run opsguard scan
+        run: poetry run opsguard scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Cada entrada está vinculada a su Pull Request en GitHub para trazabilidad compl
 
 ### Added
 
+- **[PR #44]** Pipeline CI/CD reestructurado en 3 jobs independientes con caché de Poetry y matrix de Python — el workflow de un único job se divide en: `lint` (black --check), `test` (matrix Python 3.11 + 3.12), `security-scan` (opsguard scan, depende de que lint y test pasen). Se añade `actions/cache@v4` para el virtualenv de Poetry, reduciendo el tiempo de instalación en runs sucesivos. Se aplica `black` sobre todo el código fuente por primera vez (10 ficheros reformateados), garantizando que el job de lint no falle en el primer run.
+  - Ficheros: `.github/workflows/opsguard.yml`, `src/`, `tests/`
+  - Rama: `feat/cicd-pipeline-improvements` → `main`
+
 - **[PR #43]** Sequence diagram de actores en runtime añadido al README — complementa el flowchart de alto nivel con un diagrama de secuencia Mermaid que muestra los actores reales (GitHub Actions, Gate 1, Gate 2, OpenRouter API) y los flujos condicionales de BLOCK/APPROVE con sus notas de contexto (ADR-0001).
   - Fichero: `README.md`
   - Rama: `feat/architecture-improvements` → `main`

--- a/src/ai.py
+++ b/src/ai.py
@@ -15,7 +15,9 @@ _console = Console()
 
 class AIEngineError(Exception):
     """Custom exception for AI Engine failures."""
+
     pass
+
 
 # --- FINOPS CONFIGURATION (Unit Economic) ---
 # Pricing for google/gemini-2.0-flash-001 (OpenRouter/Google pricing)
@@ -64,6 +66,7 @@ OUTPUT FORMAT (Strict JSON):
 }
 """
 
+
 class AIEngine:
     def __init__(self):
         raw_key = os.getenv("OPENROUTER_API_KEY")
@@ -71,24 +74,26 @@ class AIEngine:
             raise AIEngineError("❌ Missing OPENROUTER_API_KEY")
 
         self.api_key = raw_key.strip().strip('"').strip("'")
-        
+
         extra_headers = {
             "HTTP-Referer": "https://opsguard.local",
-            "X-Title": "OpsGuard-TFM"
+            "X-Title": "OpsGuard-TFM",
         }
 
         self.client = OpenAI(
             base_url="https://openrouter.ai/api/v1",
             api_key=self.api_key,
             default_headers=extra_headers,
-            timeout=60.0
+            timeout=60.0,
         )
-        
+
         self.model = os.getenv("OPSGUARD_MODEL", "google/gemini-2.0-flash-001")
 
     def analyze_diff(self, diff_text: str) -> Dict[str, Any]:
         if TELEMETRY_MODE != "silent":
-            _console.print(f"🤖 OpsGuard Brain: Sending diff to [cyan]{self.model}[/cyan]...")
+            _console.print(
+                f"🤖 OpsGuard Brain: Sending diff to [cyan]{self.model}[/cyan]..."
+            )
         if TELEMETRY_MODE == "verbose":
             _console.print(f"📦 Context Payload: {len(diff_text)} chars")
 
@@ -102,7 +107,7 @@ class AIEngine:
             _console.print(
                 f"⚠️  Diff truncated: {original_len} → {MAX_DIFF_CHARS} chars "
                 f"({chars_lost} discarded)",
-                style="yellow"
+                style="yellow",
             )
 
         try:
@@ -110,11 +115,14 @@ class AIEngine:
                 model=self.model,
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},
-                    {"role": "user", "content": f"Analyze this git diff:\n\n{truncated_diff}"}
+                    {
+                        "role": "user",
+                        "content": f"Analyze this git diff:\n\n{truncated_diff}",
+                    },
                 ],
                 temperature=0.1,  # Deterministic: reduces hallucinations
                 max_tokens=1024,
-                response_format={"type": "json_object"}
+                response_format={"type": "json_object"},
             )
 
             end_time = time.time()
@@ -123,7 +131,7 @@ class AIEngine:
             if TELEMETRY_MODE == "verbose":
                 _console.print(
                     f"⏱️  AI Analysis Time: {total_latency_ms / 1000:.2f}s",
-                    style="cyan"
+                    style="cyan",
                 )
 
             # --- FINOPS TELEMETRY (ADR-0003) ---
@@ -139,13 +147,17 @@ class AIEngine:
                     title="💰 FinOps Telemetry",
                     box=box.MARKDOWN,
                     style="green",
-                    title_style="bold green"
+                    title_style="bold green",
                 )
                 table.add_column("Metric", style="bold")
                 table.add_column("Value")
                 table.add_column("Unit Cost")
-                table.add_row("Input Tokens", str(input_tok), f"${PRICE_PER_1M_INPUT}/1M")
-                table.add_row("Output Tokens", str(output_tok), f"${PRICE_PER_1M_OUTPUT}/1M")
+                table.add_row(
+                    "Input Tokens", str(input_tok), f"${PRICE_PER_1M_INPUT}/1M"
+                )
+                table.add_row(
+                    "Output Tokens", str(output_tok), f"${PRICE_PER_1M_OUTPUT}/1M"
+                )
                 table.add_row("Total Latency", f"{total_latency_ms}ms", "N/A")
                 # TTFT requires streaming mode; non-streaming total latency ≈ TTFT.
                 table.add_row("TTFT (approx)", f"{total_latency_ms}ms", "non-streaming")
@@ -159,12 +171,14 @@ class AIEngine:
             try:
                 parsed_data = json.loads(clean_content)
             except json.JSONDecodeError:
-                _console.print(f"⚠️ RAW AI RESPONSE (JSON Error): {clean_content}", style="yellow")
+                _console.print(
+                    f"⚠️ RAW AI RESPONSE (JSON Error): {clean_content}", style="yellow"
+                )
                 return {
                     "verdict": "BLOCK",
                     "risk_score": 10,
                     "explanation": "AI output parsing failed. Manual review required.",
-                    "findings": []
+                    "findings": [],
                 }
 
             # Normalisation: handle unexpected list responses
@@ -174,8 +188,10 @@ class AIEngine:
             return {
                 "verdict": parsed_data.get("verdict", "BLOCK"),
                 "risk_score": parsed_data.get("risk_score", 0),
-                "explanation": parsed_data.get("explanation", "No explanation provided."),
-                "findings": parsed_data.get("findings", [])
+                "explanation": parsed_data.get(
+                    "explanation", "No explanation provided."
+                ),
+                "findings": parsed_data.get("findings", []),
             }
 
         except Exception as e:
@@ -185,5 +201,5 @@ class AIEngine:
                 "verdict": "BLOCK",
                 "risk_score": 10,
                 "explanation": f"Internal Engine Error: {str(e)}",
-                "findings": []
+                "findings": [],
             }

--- a/src/console_ui.py
+++ b/src/console_ui.py
@@ -5,14 +5,16 @@ from rich import box
 
 console = Console()
 
+
 class OpsGuardUI:
-    
     @staticmethod
     def print_banner():
-        console.print(Panel.fit(
-            "[bold cyan]🛡️ OpsGuard-AI[/bold cyan]\n[dim]Security Gate Active[/dim]",
-            border_style="cyan"
-        ))
+        console.print(
+            Panel.fit(
+                "[bold cyan]🛡️ OpsGuard-AI[/bold cyan]\n[dim]Security Gate Active[/dim]",
+                border_style="cyan",
+            )
+        )
 
     @staticmethod
     def print_regex_findings(findings: list):
@@ -20,20 +22,26 @@ class OpsGuardUI:
             console.print("✅ [green]No static credential patterns found.[/green]")
             return
 
-        console.print(f"\n[bold red]🚨 DETECTED {len(findings)} STATIC VIOLATIONS:[/bold red]")
-        table = Table(show_header=True, header_style="bold white on red", box=box.ROUNDED)
+        console.print(
+            f"\n[bold red]🚨 DETECTED {len(findings)} STATIC VIOLATIONS:[/bold red]"
+        )
+        table = Table(
+            show_header=True, header_style="bold white on red", box=box.ROUNDED
+        )
         table.add_column("Type")
         table.add_column("File")
-        
+
         for f in findings:
             table.add_row(f.get("type"), f.get("file"))
-        
+
         console.print(table)
 
     @staticmethod
     def print_ai_analysis(result: dict):
-        console.print("\n[bold blue]╭─────────────────────────── 🧠 AI Context Analysis ───────────────────────────╮[/bold blue]")
-        
+        console.print(
+            "\n[bold blue]╭─────────────────────────── 🧠 AI Context Analysis ───────────────────────────╮[/bold blue]"
+        )
+
         verdict = result.get("verdict", "UNKNOWN")
         score = result.get("risk_score", 0)
         explanation = result.get("explanation", "No details.")
@@ -44,16 +52,23 @@ class OpsGuardUI:
             v_style = "bold green"
         else:
             v_style = "bold white on red"
-        
+
         console.print(f"│         🤖 Verdict: [{v_style}] {verdict} [/{v_style}]")
         console.print(f"│         🔥 Risk Score: {score}/10")
         console.print(f"│         📝 Summary: [italic]{explanation}[/italic]")
-        console.print("╰──────────────────────────────────────────────────────────────────────────────╯")
+        console.print(
+            "╰──────────────────────────────────────────────────────────────────────────────╯"
+        )
 
         if findings:
             console.print("\n[bold red]🕵️‍♂️  AI FORENSIC FINDINGS:[/bold red]")
-            
-            table = Table(show_header=True, header_style="bold white on red", border_style="red", box=box.HEAVY_HEAD)
+
+            table = Table(
+                show_header=True,
+                header_style="bold white on red",
+                border_style="red",
+                box=box.HEAVY_HEAD,
+            )
             table.add_column("Sev", justify="center", width=8)
             table.add_column("File", style="cyan")
             table.add_column("Line", style="yellow")
@@ -63,20 +78,24 @@ class OpsGuardUI:
                 sev = finding.get("severity", "UNK")
                 # Critical severity highlighting
                 sev_color = "red" if sev in ["CRITICAL", "HIGH"] else "yellow"
-                
+
                 table.add_row(
                     f"[{sev_color}]{sev}[/{sev_color}]",
                     finding.get("file", "-"),
                     str(finding.get("line", "?")),
-                    finding.get("issue", "No description")
+                    finding.get("issue", "No description"),
                 )
-            
+
             console.print(table)
 
     @staticmethod
     def print_block_message():
-        console.print("\n[bold white on red] ⛔ PIPELINE BLOCKED: SECURITY VIOLATION DETECTED [/bold white on red]")
+        console.print(
+            "\n[bold white on red] ⛔ PIPELINE BLOCKED: SECURITY VIOLATION DETECTED [/bold white on red]"
+        )
 
     @staticmethod
     def print_success_message():
-        console.print("\n[bold black on green] ✅ PIPELINE APPROVED: CODE IS SECURE [/bold black on green]")
+        console.print(
+            "\n[bold black on green] ✅ PIPELINE APPROVED: CODE IS SECURE [/bold black on green]"
+        )

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -9,6 +9,7 @@ from git.exc import GitCommandError, InvalidGitRepositoryError
 
 class GitIngestError(Exception):
     """Custom exception for git ingestion errors."""
+
     pass
 
 
@@ -18,6 +19,7 @@ class SkipScanSignal(GitIngestError):
     Examples: direct push to main, branch deletion. These are valid
     git events but OpsGuard only operates on Pull Requests.
     """
+
     pass
 
 
@@ -67,15 +69,19 @@ class GitManager:
             # No PR object — check if this is an event we should skip
             # (merges to main, branch deletions, direct pushes)
             if "pusher" in event_data or "deleted" in event_data:
-                raise SkipScanSignal("Event is not a Pull Request (Push/Delete detected).")
-            
+                raise SkipScanSignal(
+                    "Event is not a Pull Request (Push/Delete detected)."
+                )
+
             raise GitIngestError("No pull_request data found in GitHub event")
 
         base_sha = pull_request.get("base", {}).get("sha")
         head_sha = pull_request.get("head", {}).get("sha")
 
         if not base_sha or not head_sha:
-            raise GitIngestError("Missing base.sha or head.sha in pull_request event data")
+            raise GitIngestError(
+                "Missing base.sha or head.sha in pull_request event data"
+            )
 
         self._shas_cache = (base_sha, head_sha)
         return self._shas_cache
@@ -94,9 +100,9 @@ class GitManager:
             else:
                 # Equivalent to: git diff --name-only HEAD
                 diff_text = self.repo.git.diff("HEAD", name_only=True)
-            
+
             return diff_text.splitlines() if diff_text else []
-            
+
         except GitCommandError as e:
             raise GitIngestError(f"Failed to list staged files: {e}")
 
@@ -104,7 +110,7 @@ class GitManager:
         """Get the git diff based on environment and strict file filtering.
 
         Args:
-            files: Optional list of files to limit the diff to. 
+            files: Optional list of files to limit the diff to.
                    If provided, only changes in these files are returned.
 
         Returns:

--- a/src/main.py
+++ b/src/main.py
@@ -9,18 +9,22 @@ app = typer.Typer(
     name="opsguard",
     help="AI-powered DevOps guardian for code review and security analysis.",
     no_args_is_help=True,
-    add_completion=False
+    add_completion=False,
 )
+
 
 @app.callback()
 def main_callback():
     """OpsGuard AI Security Gate Entrypoint."""
     pass
 
+
 @app.command()
 def scan(
     path: Annotated[str, typer.Option(help="Path to the repository to scan.")] = ".",
-    config: Annotated[str, typer.Option(help="Path to security policy config.")] = "opsguard.yml",
+    config: Annotated[
+        str, typer.Option(help="Path to security policy config.")
+    ] = "opsguard.yml",
 ) -> None:
     """
     Hybrid Security Gate: Regex Shield + AI Brain.
@@ -41,7 +45,7 @@ def scan(
         if ignore_path.exists():
             with open(ignore_path, "r") as f:
                 lines = f.read().splitlines()
-        lines.extend([".git/", "*.lock"]) 
+        lines.extend([".git/", "*.lock"])
         return pathspec.PathSpec.from_lines("gitwildmatch", lines)
 
     # 1. Init & Git Context
@@ -49,19 +53,16 @@ def scan(
         root_path = Path(path)
         policy = SecurityPolicy(config_path=config)
         manager = GitManager(repo_path=str(root_path))
-        
+
         # Pre-filtering Stage
         ignore_spec = _load_ignore_spec(root_path)
-        
+
         # [SECURITY AUDIT NOTE]
         # Implementation of Standard Ignore Mechanism.
         # This uses 'pathspec' to filter non-code artifacts.
-        all_staged_files = manager.get_staged_files() 
-        
-        target_files = [
-            f for f in all_staged_files 
-            if not ignore_spec.match_file(f)
-        ]
+        all_staged_files = manager.get_staged_files()
+
+        target_files = [f for f in all_staged_files if not ignore_spec.match_file(f)]
 
         if not target_files:
             print("✨ No relevant changes detected (filtered by .opsguardignore).")
@@ -78,7 +79,10 @@ def scan(
         raise typer.Exit(code=0)
 
     except AttributeError:
-        typer.secho("❌ API Mismatch: GitManager is missing the 'get_staged_files()' method.", fg=typer.colors.RED)
+        typer.secho(
+            "❌ API Mismatch: GitManager is missing the 'get_staged_files()' method.",
+            fg=typer.colors.RED,
+        )
         sys.exit(1)
 
     except Exception as e:
@@ -93,17 +97,21 @@ def scan(
     violations = policy.scan_diff(diff)
 
     if violations:
-        formatted_findings = [{"file": "Diff", "line": "?", "type": v} for v in violations]
+        formatted_findings = [
+            {"file": "Diff", "line": "?", "type": v} for v in violations
+        ]
         OpsGuardUI.print_regex_findings(formatted_findings)
         OpsGuardUI.print_block_message()
         sys.exit(1)
 
-    OpsGuardUI.print_regex_findings([]) 
+    OpsGuardUI.print_regex_findings([])
 
     # 3. Gate 2: Semantic Brain (AI Analysis)
     api_key = os.getenv("OPENROUTER_API_KEY")
     if not api_key:
-        typer.secho("⚠️ Missing OPENROUTER_API_KEY. Skipping AI.", fg=typer.colors.YELLOW)
+        typer.secho(
+            "⚠️ Missing OPENROUTER_API_KEY. Skipping AI.", fg=typer.colors.YELLOW
+        )
         return
 
     try:
@@ -125,6 +133,7 @@ def scan(
         sys.exit(1)
     else:
         OpsGuardUI.print_success_message()
+
 
 if __name__ == "__main__":
     app(prog_name="opsguard")

--- a/src/security.py
+++ b/src/security.py
@@ -44,9 +44,7 @@ class SecurityPolicy:
         config_file = Path(config_path)
 
         if not config_file.exists():
-            raise SecurityPolicyError(
-                f"Configuration file not found: {config_path}"
-            )
+            raise SecurityPolicyError(f"Configuration file not found: {config_path}")
 
         try:
             content = config_file.read_text(encoding="utf-8")
@@ -76,10 +74,12 @@ class SecurityPolicy:
             # Pre-compile regex for performance
             try:
                 compiled = re.compile(rule["pattern"])
-                self.rules.append({
-                    "name": rule["name"],
-                    "pattern": compiled,
-                })
+                self.rules.append(
+                    {
+                        "name": rule["name"],
+                        "pattern": compiled,
+                    }
+                )
             except re.error as e:
                 raise SecurityPolicyError(
                     f"Invalid regex in rule '{rule['name']}': {e}"

--- a/tests/fixtures/vulnerable_app/auth_middleware.py
+++ b/tests/fixtures/vulnerable_app/auth_middleware.py
@@ -1,12 +1,13 @@
 import os
 
+
 def validate_request(headers):
     """
     Standard header validation for internal API calls.
     Verifies the presence of the X-API-KEY.
     """
     api_key = headers.get("X-API-KEY")
-    
+
     # -------------------------------------------------------
     # VULNERABILITY: Developer Backdoor
     # Intentional bypass for "debugging" purposes.
@@ -14,8 +15,8 @@ def validate_request(headers):
     # -------------------------------------------------------
     if headers.get("X-DEBUG-MODE") == "true":
         return True  # Bypass auth completely
-        
+
     if not api_key:
         return False
-        
+
     return api_key == os.getenv("SERVICE_SECRET")

--- a/tests/fixtures/vulnerable_app/legacy_login.py
+++ b/tests/fixtures/vulnerable_app/legacy_login.py
@@ -1,8 +1,9 @@
 import sqlite3
 
+
 def get_user(username):
     # SQL Injection clara para que la IA se luzca
-    query = f"SELECT * FROM users WHERE name = '{username}'" 
-    conn = sqlite3.connect('db.sqlite')
+    query = f"SELECT * FROM users WHERE name = '{username}'"
+    conn = sqlite3.connect("db.sqlite")
     cursor = conn.execute(query)
     return cursor.fetchone()

--- a/tests/fixtures/vulnerable_app/supply_chain_attack.py
+++ b/tests/fixtures/vulnerable_app/supply_chain_attack.py
@@ -6,27 +6,32 @@ import subprocess
 import os
 
 # Container registry configuration
-REGISTRY = "ghrc.io"  # TYPOSQUATTING: This should be ghcr.io (GitHub Container Registry)
+REGISTRY = (
+    "ghrc.io"  # TYPOSQUATTING: This should be ghcr.io (GitHub Container Registry)
+)
 ORG = "acme-corp"
 IMAGE_NAME = "payment-service"
+
 
 def build_and_push(tag: str = "latest"):
     """Build Docker image and push to registry."""
     full_image = f"{REGISTRY}/{ORG}/{IMAGE_NAME}:{tag}"
-    
+
     print(f"Building image: {full_image}")
     subprocess.run(["docker", "build", "-t", full_image, "."], check=True)
-    
+
     print(f"Pushing to registry: {REGISTRY}")
     subprocess.run(["docker", "push", full_image], check=True)
-    
+
     return full_image
+
 
 def pull_base_image():
     """Pull base image from registry."""
     base = f"ghrc.io/acme-corp/base-python:3.12-slim"
     subprocess.run(["docker", "pull", base], check=True)
     return base
+
 
 if __name__ == "__main__":
     tag = os.getenv("IMAGE_TAG", "latest")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -31,6 +31,7 @@ from src.ingest import GitManager, GitIngestError, SkipScanSignal
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def write_event(tmp_path: Path, payload: dict) -> str:
     """Write a GitHub Actions event JSON file and return its path."""
     event_file = tmp_path / "event.json"
@@ -41,6 +42,7 @@ def write_event(tmp_path: Path, payload: dict) -> str:
 # ---------------------------------------------------------------------------
 # GitManager initialisation
 # ---------------------------------------------------------------------------
+
 
 class TestGitManagerInit:
     """GitManager must accept a valid repository and fail clearly on bad input."""
@@ -59,6 +61,7 @@ class TestGitManagerInit:
 # ---------------------------------------------------------------------------
 # CI environment detection
 # ---------------------------------------------------------------------------
+
 
 class TestCIDetection:
     """is_ci() must reflect the presence of the GITHUB_ACTIONS environment variable."""
@@ -79,6 +82,7 @@ class TestCIDetection:
 # ---------------------------------------------------------------------------
 # GitHub event JSON parsing — _get_ci_shas()
 # ---------------------------------------------------------------------------
+
 
 class TestCISHAParsing:
     """_get_ci_shas() must parse GitHub event payloads correctly and fail clearly."""
@@ -122,7 +126,9 @@ class TestCISHAParsing:
         with pytest.raises(SkipScanSignal):
             manager._get_ci_shas()
 
-    def test_raises_skip_signal_on_branch_delete_event(self, manager, monkeypatch, tmp_path):
+    def test_raises_skip_signal_on_branch_delete_event(
+        self, manager, monkeypatch, tmp_path
+    ):
         """A branch deletion event (has 'deleted' key) must raise SkipScanSignal."""
         payload = {"deleted": True, "ref": "refs/heads/old-feature"}
         monkeypatch.setenv("GITHUB_EVENT_PATH", write_event(tmp_path, payload))
@@ -137,7 +143,9 @@ class TestCISHAParsing:
 
     # --- GitIngestError: events with unexpected structure ---
 
-    def test_raises_when_no_pull_request_and_no_skip_trigger(self, manager, monkeypatch, tmp_path):
+    def test_raises_when_no_pull_request_and_no_skip_trigger(
+        self, manager, monkeypatch, tmp_path
+    ):
         """An unknown event without 'pull_request', 'pusher', or 'deleted' is
         an unrecognised payload — raise GitIngestError (not SkipScanSignal).
         """
@@ -146,7 +154,9 @@ class TestCISHAParsing:
         with pytest.raises(GitIngestError, match="No pull_request data"):
             manager._get_ci_shas()
 
-    def test_raises_when_pull_request_missing_base_sha(self, manager, monkeypatch, tmp_path):
+    def test_raises_when_pull_request_missing_base_sha(
+        self, manager, monkeypatch, tmp_path
+    ):
         """PR event without base.sha / head.sha is malformed — raise GitIngestError."""
         payload = {"pull_request": {"title": "Incomplete PR payload"}}
         monkeypatch.setenv("GITHUB_EVENT_PATH", write_event(tmp_path, payload))
@@ -155,7 +165,9 @@ class TestCISHAParsing:
 
     # --- Happy path ---
 
-    def test_returns_correct_shas_from_valid_pr_event(self, manager, monkeypatch, tmp_path):
+    def test_returns_correct_shas_from_valid_pr_event(
+        self, manager, monkeypatch, tmp_path
+    ):
         """A well-formed PR event must return (base_sha, head_sha) as strings."""
         payload = {
             "pull_request": {

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -79,9 +79,9 @@ class TestGate1SecretDetection:
         violations = self.policy.scan_diff(make_diff(content))
 
         assert len(violations) > 0, "Expected AWS key violation, got none"
-        assert any("AWS" in v for v in violations), (
-            f"Violation must reference AWS rule. Got: {violations}"
-        )
+        assert any(
+            "AWS" in v for v in violations
+        ), f"Violation must reference AWS rule. Got: {violations}"
 
     def test_aws_violation_message_contains_pattern_name(self):
         """Each violation message must include the rule name for audit traceability."""
@@ -144,9 +144,9 @@ class TestGate1DoesNotOverreach:
         content = (FIXTURES / "config.php").read_text()
         violations = self.policy.scan_diff(make_diff(content))
 
-        assert violations == [], (
-            f"PHP generic password should reach Gate 2 (AI). Got: {violations}"
-        )
+        assert (
+            violations == []
+        ), f"PHP generic password should reach Gate 2 (AI). Got: {violations}"
 
     def test_supply_chain_typosquatting_passes_gate1(self):
         """supply_chain_attack.py — typosquatting domain (ghrc.io vs ghcr.io).
@@ -159,9 +159,9 @@ class TestGate1DoesNotOverreach:
         content = (FIXTURES / "supply_chain_attack.py").read_text()
         violations = self.policy.scan_diff(make_diff(content))
 
-        assert violations == [], (
-            f"Supply-chain typosquatting should reach Gate 2 (AI). Got: {violations}"
-        )
+        assert (
+            violations == []
+        ), f"Supply-chain typosquatting should reach Gate 2 (AI). Got: {violations}"
 
 
 # ---------------------------------------------------------------------------
@@ -185,9 +185,9 @@ class TestDiffBehavior:
             "-AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"
         )
         violations = self.policy.scan_diff(diff)
-        assert violations == [], (
-            f"Removed secrets must not be flagged. Got: {violations}"
-        )
+        assert (
+            violations == []
+        ), f"Removed secrets must not be flagged. Got: {violations}"
 
     def test_diff_header_lines_are_ignored(self):
         """Lines starting with '+++' are diff metadata, not code."""
@@ -209,6 +209,6 @@ class TestDiffBehavior:
             "+GITHUB_TOKEN=ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ123456789A\n"
         )
         violations = self.policy.scan_diff(diff)
-        assert len(violations) >= 2, (
-            f"Expected at least 2 violations, got {len(violations)}: {violations}"
-        )
+        assert (
+            len(violations) >= 2
+        ), f"Expected at least 2 violations, got {len(violations)}: {violations}"


### PR DESCRIPTION
Replaces the single security-audit job with a 3-job pipeline:

  lint → test → security-scan

lint:
  - Runs black --check src/ tests/ to enforce consistent formatting.
  - All 10 source files formatted with black prior to this commit.

test:
  - Matrix strategy: Python 3.11 and 3.12 (matches pyproject.toml ^3.11).
  - fail-fast: false so both versions always report independently.
  - Runs the full 28-test suite (poetry run pytest tests/ -v).

security-scan:
  - needs: [lint, test] — only runs when quality gates pass.
  - fetch-depth: 0 retained for SHA comparison.
  - OPENROUTER_API_KEY + OPSGUARD_RISK_THRESHOLD injected as before.

All 3 jobs use actions/cache@v4 keyed on poetry.lock hash to avoid re-installing dependencies on every run. Removes deprecated --sync flag from poetry install.