### PR TITLE
docs: ADR-0004 fail-closed policy + ai.py module contracts (Architecture v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Cada entrada está vinculada a su Pull Request en GitHub para trazabilidad compl
 
 ---
 
+## [0.6.0] — 2026-03-01 · Architecture Documentation Sprint
+
+> Ciclo de mejora de arquitectura iniciado a partir del criterio **Arquitectura y Diseño Técnico** (9.0/10, gap −1.0 pt). La evaluación señalaba un único punto ciego: la política fail-closed de Gate 2 existía en el código pero no estaba documentada como decisión consciente. Este sprint lo cierra con el ADR que faltaba y completa los contratos de módulo de `src/ai.py`.
+
+### Added
+
+- **[PR #51]** ADR-0004: Política Fail-Closed en Gate 2 — Documenta formalmente el trade-off arquitectónico entre **disponibilidad** (fail-open: el pipeline continúa si la IA falla) y **seguridad** (fail-closed: el pipeline se bloquea si la IA falla). La decisión elegida es fail-closed: cualquier excepción en `analyze_diff()` retorna `verdict: BLOCK, risk_score: 10` sin propagar el error. El ADR recoge la justificación de seguridad, las consecuencias negativas (impacto en disponibilidad ante caídas de OpenRouter) y las mitigaciones operacionales recomendadas para producción.
+  - Fichero: `docs/adr/0004-fail-closed-policy.md`
+  - Rama: `feat/architecture-documentation` → `main`
+
+- **[PR #51]** Docstrings de contrato en `src/ai.py` — `AIEngine` y `analyze_diff()` eran los únicos módulos del sistema sin contratos documentados. Se añaden:
+  - Docstring de clase `AIEngine`: describe su responsabilidad (Gate 2 semántico), la dependencia de OpenRouter y la referencia explícita a ADR-0004 para la política de errores.
+  - Docstring de `__init__`: documenta la excepción `AIEngineError` que lanza si falta `OPENROUTER_API_KEY`.
+  - Docstring de `analyze_diff()`: documenta los args, el dict de retorno completo (keys `verdict`, `risk_score`, `explanation`, `findings`) y el contrato de no-lanzamiento de excepciones con referencia a ADR-0004 y ADR-0005.
+  - Fichero: `src/ai.py`
+  - Rama: `feat/architecture-documentation` → `main`
+
+---
+
 ## [0.5.0] — 2026-03-01 · Code Quality Sprint
 
 > Ciclo de mejora de implementación iniciado tras el análisis de brechas del informe de evaluación TFM. El criterio **Implementación del Código** obtuvo un 8.5/10 (gap de −1.5 pts) por tres decisiones de implementación incompletas: el `SYSTEM_PROMPT` hardcodeado en lugar de externalizado, la falta de documentación formal de la deuda técnica del truncado de diff, y la ausencia de auditoría automática de dependencias en CI.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Para profundizar en las decisiones de arquitectura, costes y privacidad, consult
 - [ADR-001: Patrón Gatekeeper Local](/docs/adr/0001-patron-gatekeeper-local.md)
 - [ADR-002: Prompt Engineering & English Tokens](/docs/adr/0002-prompting-en-ingles.md)
 - [ADR-003: Telemetría y FinOps](/docs/adr/0003-telemetria-y-finops.md)
+- [ADR-004: Política Fail-Closed en Gate 2](/docs/adr/0004-fail-closed-policy.md)
 - [ADR-005: Estrategia de Truncado de Diff](/docs/adr/0005-diff-truncation-strategy.md)
 
 ---
@@ -237,6 +238,7 @@ No es un simple historial de commits: cada entrada describe el **problema identi
 
 | Versión | Descripción |
 |---------|-------------|
+| `0.6.0` | Architecture Documentation Sprint — ADR-0004 fail-closed, contratos de módulo |
 | `0.5.0` | Code Quality Sprint — prompt externalizado, ADR-0005, auditoría CVE en CI |
 | `0.4.0` | Testing Coverage Sprint — tests AIEngine, E2E pipeline, gate cobertura 80% |
 | `0.3.0` | Quality Audit Sprint — corrección de blockers, tests unitarios, telemetría ADR-0003, principio de mínimo privilegio |

--- a/docs/adr/0004-fail-closed-policy.md
+++ b/docs/adr/0004-fail-closed-policy.md
@@ -1,0 +1,71 @@
+# ADR 0004: Política Fail-Closed en Gate 2
+
+## Estado
+Aceptado
+
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| **Date** | 2026-03-01 |
+| **Deciders** | Óscar Sánchez Pérez |
+
+## Contexto
+
+Gate 2 (`src/ai.py`) depende de una API externa (OpenRouter) para realizar el análisis semántico del diff. Esta dependencia introduce un punto de fallo ajeno al control del equipo: la API puede estar caída, el timeout puede agotarse, la respuesta puede llegar malformada o en un formato inesperado, o la API key puede haber expirado.
+
+Cuando cualquiera de estos fallos ocurre en un sistema de seguridad, hay que tomar una decisión arquitectónica fundamental:
+
+> **¿Debe el pipeline bloquearse o continuar cuando el motor de IA no puede emitir un veredicto?**
+
+Las dos opciones son:
+
+| Política | Comportamiento ante fallo | Principio que prioriza |
+|----------|--------------------------|------------------------|
+| **Fail-open** | El pipeline continúa (`APPROVE`) | Disponibilidad / velocidad de desarrollo |
+| **Fail-closed** | El pipeline se bloquea (`BLOCK`, `risk_score: 10`) | Seguridad / defensa en profundidad |
+
+## Decisión
+
+OpsGuard implementa **fail-closed**: cualquier excepción no controlada en `analyze_diff()` retorna un veredicto de bloqueo con `risk_score: 10`, sin propagar la excepción al orquestador.
+
+```python
+except Exception as e:
+    # Fail closed: any engine failure blocks the pipeline.
+    return {
+        "verdict": "BLOCK",
+        "risk_score": 10,
+        "explanation": f"Internal Engine Error: {str(e)}",
+        "findings": [],
+    }
+```
+
+El mismo principio aplica a fallos internos de parseo (JSON malformado, tipo de respuesta inesperado): en lugar de propagar la excepción, se retorna inmediatamente un veredicto de bloqueo.
+
+## Justificación
+
+OpsGuard es una **puerta de seguridad**, no un servicio de productividad. Su contrato con el equipo es: *"Si no puedo garantizar que el código es seguro, no dejo que pase."*
+
+Un fallo silencioso en Gate 2 que permitiera el merge de código malicioso sería un fallo de seguridad. Un fallo en Gate 2 que bloquee temporalmente el pipeline es una interrupción operacional recuperable.
+
+En sistemas de seguridad, la disponibilidad es secundaria a la integridad. Esta es la misma lógica que aplican los firewalls con su política por defecto `DENY ALL` o los validadores de certificados TLS que rechazan conexiones ante cualquier anomalía.
+
+## Consecuencias
+
+### Positivas
+- **Seguridad garantizada ante fallos**: ningún PR puede pasar silenciosamente por un error técnico del motor de IA.
+- **Comportamiento predecible**: los equipos saben que ante cualquier error del sistema, el pipeline se detiene — no pasa nada de forma inadvertida.
+- **Sin superficie de ataque por degradación**: un atacante no puede provocar intencionadamente un fallo del motor (p.ej. enviando un diff que consuma todo el contexto) para que el sistema apruebe código malicioso por omisión.
+
+### Negativas
+- **Impacto en disponibilidad**: una caída de OpenRouter, un agotamiento de cuota o una expiración de la API key bloqueará **todos** los PRs del equipo hasta que se resuelva el problema operacional.
+- **Falsos bloqueos no auditables**: el bloqueo por fallo de motor no genera findings técnicos — solo un mensaje de error interno. El equipo necesita monitorización externa (alertas de CI, dashboards) para distinguir un bloqueo por amenaza real de un bloqueo por fallo de infraestructura.
+
+## Mitigaciones para producción
+
+Para reducir el impacto de los fallos de disponibilidad sin sacrificar la política de seguridad:
+
+1. **Monitorización del job `security-scan`**: distinguir en los dashboards de CI entre `exit 1` por amenaza detectada vs `exit 1` por error de motor (el mensaje de consola los diferencia).
+2. **Configurar alertas de OpenRouter** para cuota y latencia anómala.
+3. **Usar el modo `OPSGUARD_TELEMETRY_MODE=verbose`** en CI para que los logs incluyan el error exacto que causó el bloqueo.
+4. **Timeout explícito de 60s** en el cliente OpenAI para evitar que el job de CI quede colgado indefinidamente.

--- a/src/ai.py
+++ b/src/ai.py
@@ -43,7 +43,23 @@ SYSTEM_PROMPT = _PROMPT_PATH.read_text(encoding="utf-8")
 
 
 class AIEngine:
-    def __init__(self):
+    """Gate 2: semantic security analysis engine powered by an LLM via OpenRouter.
+
+    Sends the git diff to a large language model for contextual reasoning about
+    security vulnerabilities that deterministic regex cannot detect (SQL injection,
+    logic backdoors, supply-chain typosquatting, etc.).
+
+    Error policy (ADR-0004): fail-closed. Any exception raised during analysis
+    returns a BLOCK verdict with risk_score=10 rather than propagating the error.
+    This guarantees that no PR passes silently through an engine failure.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the AI engine and validate the OpenRouter API key.
+
+        Raises:
+            AIEngineError: If OPENROUTER_API_KEY is not set in the environment.
+        """
         raw_key = os.getenv("OPENROUTER_API_KEY")
         if not raw_key:
             raise AIEngineError("❌ Missing OPENROUTER_API_KEY")
@@ -65,6 +81,28 @@ class AIEngine:
         self.model = os.getenv("OPSGUARD_MODEL", "google/gemini-2.0-flash-001")
 
     def analyze_diff(self, diff_text: str) -> Dict[str, Any]:
+        """Analyse a git diff for security vulnerabilities using an LLM.
+
+        Truncates the diff to MAX_DIFF_CHARS before sending it to the model
+        to keep cost and latency predictable (ADR-0005).
+
+        Args:
+            diff_text: Raw git diff string to analyse.
+
+        Returns:
+            A dict with the following keys:
+                - ``verdict`` (str): ``"APPROVE"`` or ``"BLOCK"``.
+                - ``risk_score`` (int): 0–10. Values ≥ OPSGUARD_RISK_THRESHOLD
+                  (default 7) cause the pipeline to block.
+                - ``explanation`` (str): Executive summary of the security status.
+                - ``findings`` (list): Zero or more dicts, each with keys
+                  ``file``, ``line``, ``severity``, and ``issue``.
+
+        Note:
+            This method never raises. Any exception (network timeout, malformed
+            JSON, unexpected response type) is caught and returns a BLOCK verdict
+            with risk_score=10 (fail-closed policy, ADR-0004).
+        """
         if TELEMETRY_MODE != "silent":
             _console.print(
                 f"🤖 OpsGuard Brain: Sending diff to [cyan]{self.model}[/cyan]..."


### PR DESCRIPTION
## Summary

- `docs/adr/0004-fail-closed-policy.md` — ADR que documenta el trade-off fail-closed vs fail-open en Gate 2, solicitado explícitamente en la evaluación TFM (sección 2, gap −1.0 pt)
- Docstrings completos en `src/ai.py`: clase `AIEngine`, `__init__` y `analyze_diff()` con contrato de retorno y referencia a ADR-0004 y ADR-0005
- README: ADR-004 añadido a la lista de documentación técnica + v0.6.0 en tabla de versiones
- CHANGELOG: entrada v0.6.0 Architecture Documentation Sprint

## Test plan
- [ ] `lint` verde: black + poetry check + pip-audit sin CVEs
- [ ] `test` verde: 45 tests, 83.74% cobertura, `src/ai.py` 100%
- [ ] `security-scan` verde: OpsGuard se autoanaliza

🤖 Generated with [Claude Code](https://claude.com/claude-code)