### PR TITLE
Add staging deployment script

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,0 +1,19 @@
+"""
+Deployment script for staging environment.
+"""
+
+import boto3
+
+# AWS credentials for staging
+AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+AWS_REGION = "eu-west-1"
+
+
+def deploy_to_staging():
+    session = boto3.Session(
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+    print("Deploying to staging...")


### PR DESCRIPTION
  Add automated deployment script for staging environment using boto3.                                                                                                                
                                                                                                                                                                                      
  Configures AWS session with region and credentials to handle staging deployments.                                                                                                   
                                                                                                                                                                                      
  Nada sospechoso en el título ni la descripción  el secreto está en el código. Así el demo es más realista: parece un commit legítimo que OpsGuard intercepta.       